### PR TITLE
github-pr-author: Use global color variables

### DIFF
--- a/github-pr-author.user.js
+++ b/github-pr-author.user.js
@@ -118,7 +118,7 @@
         }
 
         function addBox() {
-            let box = $('<div id="lm_gh_result" style="position: fixed; top:54px; right:0px; border-left:1px solid #e1e4e8; border-bottom:1px solid #e1e4e8; background-color:#fafbfc; min-width:10px; min-height:10px;"/>');
+            let box = $('<div id="lm_gh_result" style="position: fixed; top:54px; right:0px; border-left:1px solid var(--color-border-secondary); border-bottom:1px solid var(--color-border-secondary); background-color:var(--color-bg-secondary); min-width:10px; min-height:10px;"/>');
             $('body').append(box);
             $('#lm_gh_result')
                 .html('<span>Querying</span>')
@@ -159,7 +159,7 @@
                 });
                 $.each(all, function(index) {
                     let point = all[index];
-                    result += '<pre style="border-top:1px solid #e1e4e8">';
+                    result += '<pre style="border-top:1px solid var(--color-border-secondary)">';
                     result += point.commit.join('') + '\n';
                     result += point.author;
                     result += '</pre>';


### PR DESCRIPTION
This allows to support different GitHub themes

## Preview
<details>
  <summary>Default light</summary>

  ![image](https://user-images.githubusercontent.com/578406/116474036-a6a45580-a880-11eb-8483-df3724705de6.png)
</details>

<details>
  <summary>Default dark</summary>

  ![image](https://user-images.githubusercontent.com/578406/116474069-b2901780-a880-11eb-8f97-6acc8deab5f4.png)
</details>

<details>
  <summary>Dark dimmed</summary>

  ![image](https://user-images.githubusercontent.com/578406/116474096-bd4aac80-a880-11eb-9293-60873bc30357.png)
</details>
